### PR TITLE
Add persistent configuration file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ tk = "*"
 matplotlib = "*"
 numpy = "*"
 pyyaml = "*"
+appdirs = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fdab7d1529792051ab92161081550362d04a1e4e5714c247f9647ffa1aa927de"
+            "sha256": "f2d05bd0ef3402d8aeb481e419b6b363faa7ce8fcabb60da1b8b799b0abc94cc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "index": "pypi",
+            "version": "==1.4.4"
+        },
         "contourpy": {
             "hashes": [
                 "sha256:041b640d4ec01922083645a94bb3b2e777e6b626788f4095cf21abbe266413c1",

--- a/csd_viewer.py
+++ b/csd_viewer.py
@@ -3,16 +3,11 @@ from pathlib import Path
 import yaml
 
 from ecris.csd.viewer import CSDViewer
+from ecris.csd.viewer.files.configuration import load_configuration, AppConfiguration
 
 def csd_viewer():
-    try:
-        with open('config.yaml') as f:
-            configuration = yaml.load(f, Loader=yaml.Loader)
-        default_path = Path(configuration['default_directory'])
-    except Exception:
-        default_path = Path('.')
 
-    app = CSDViewer(default_path)
+    app = CSDViewer(load_configuration())
     app.mainloop()
 
 # Create the main window

--- a/ecris/csd/viewer/app.py
+++ b/ecris/csd/viewer/app.py
@@ -23,11 +23,13 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 class CSDViewer(tk.Tk):
     def __init__(self, configuration: AppConfiguration | None):
         super().__init__()
-        if configuration is None:
-            configuration = create_configuration()
-        self.default_path = configuration.default_directory
+        self.configuration = configuration
+        if self.configuration is None:
+            self.configuration = create_configuration()
+        self.default_path = self.configuration.default_directory
         self.title(f"CSD Viewer (v{__version__})")
         self.pad = 5.0
+        self.variable_elements = VARIABLE_ELEMENTS + self.configuration.custom_elements
         
         self.create_widgets()
         self.create_menu()
@@ -45,7 +47,7 @@ class CSDViewer(tk.Tk):
         self.file_list = FileList(self.default_path)
         self.file_list_controls = FileListControls(self, self.file_list)
         self.plot = Plot(self) 
-        self.element_buttons = ElementButtons(self, self.plot, PERSISTANT_ELEMENTS, VARIABLE_ELEMENTS)
+        self.element_buttons = ElementButtons(self, self.plot, PERSISTANT_ELEMENTS, self.variable_elements)
         self.controls = PlotControls(self, self.plot, self.file_list, self.element_buttons)
         self.plot.set_element_indicators(self.element_buttons.element_visibility)
 

--- a/ecris/csd/viewer/files/configuration.py
+++ b/ecris/csd/viewer/files/configuration.py
@@ -1,10 +1,14 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from logging import info
 from pathlib import Path
 from tomllib import load
 from tkinter import messagebox
 import tomllib
+from typing import List
 
 from appdirs import user_config_dir
+
+from ecris.csd.viewer.analysis import Element
 
 APP_NAME = 'csd_viewer'
 APP_AUTHOR = 'lbnl_88ops'
@@ -17,6 +21,7 @@ DATA_DIRECTORY = 'default_data_directory'
 @dataclass
 class AppConfiguration:
     default_directory: Path = Path('.')
+    custom_elements: List[Element] = field(default_factory=list)
 
 def load_configuration() -> AppConfiguration | None:
     if not CONFIG_FULLPATH.exists():
@@ -25,8 +30,23 @@ def load_configuration() -> AppConfiguration | None:
         try:
             with open(CONFIG_FULLPATH, 'rb') as f:
                 config = load(f)
+                custom_elements = []
+                if 'element' in config:
+                    info('Custom elements found')
+                    for name, data in config['element'].items():
+                        info(f'Parsing custom element: {name}')
+                        try:
+                            custom_elements.append(
+                                Element(name=name, symbol=data['symbol'],
+                                        atomic_weight=data['atomic_mass'], 
+                                        atomic_number=data['atomic_number']))
+                            info(f'Parsed element {custom_elements[-1]}')
+                        except KeyError as e:
+                            info(f'Error parsing custom element: {e}')
+                            continue
                 return AppConfiguration(
                     default_directory=Path(config[DATA_DIRECTORY]).absolute(),
+                    custom_elements=custom_elements,
                 )
         except tomllib.TOMLDecodeError:
             messagebox.showerror('Error', 
@@ -37,6 +57,13 @@ def create_configuration() -> AppConfiguration:
     CONFIG_FILEPATH.mkdir(exist_ok=True)
     with open(CONFIG_FULLPATH, 'w') as f:
         f.write(f'{DATA_DIRECTORY} = "."')
+        f.write('\n\n')
+        f.write('\n'.join(["# Add custom elements like so:", 
+                           '# [element."Uranium"]', 
+                           '# symbol="U"', 
+                           '# atomic_mass=235', 
+                           '# atomic_number=92']))
+
     config = load_configuration()
     if config is None:
         raise RuntimeError

--- a/ecris/csd/viewer/files/configuration.py
+++ b/ecris/csd/viewer/files/configuration.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from pathlib import Path
+from tomllib import load
+from tkinter import messagebox
+import tomllib
+
+from appdirs import user_config_dir
+
+APP_NAME = 'csd_viewer'
+APP_AUTHOR = 'lbnl_88ops'
+CONFIG_FILENAME = 'config.toml'
+CONFIG_FILEPATH = Path(user_config_dir(APP_NAME, APP_AUTHOR)) 
+CONFIG_FULLPATH = CONFIG_FILEPATH / CONFIG_FILENAME
+
+DATA_DIRECTORY = 'default_data_directory'
+
+@dataclass
+class AppConfiguration:
+    default_directory: Path = Path('.')
+
+def load_configuration() -> AppConfiguration | None:
+    if not CONFIG_FULLPATH.exists():
+        return None
+    else:
+        try:
+            with open(CONFIG_FULLPATH, 'rb') as f:
+                config = load(f)
+                return AppConfiguration(
+                    default_directory=Path(config[DATA_DIRECTORY]).absolute(),
+                )
+        except tomllib.TOMLDecodeError:
+            messagebox.showerror('Error', 
+                                 'Error loading configuration, using default settings')
+            return AppConfiguration()
+
+def create_configuration() -> AppConfiguration:
+    CONFIG_FILEPATH.mkdir(exist_ok=True)
+    with open(CONFIG_FULLPATH, 'w') as f:
+        f.write(f'{DATA_DIRECTORY} = "."')
+    config = load_configuration()
+    if config is None:
+        raise RuntimeError
+    return config

--- a/ecris/csd/viewer/gui/menu.py
+++ b/ecris/csd/viewer/gui/menu.py
@@ -9,6 +9,11 @@ class AppMenu(tk.Menu):
     def create_menus(self, use_blitting):
         self.hamburger_menu = tk.Menu(self, tearoff=0)
         self.add_cascade(label='☰', menu=self.hamburger_menu)
+        self.hamburger_menu.add_command(label='Open data directory',
+                         command=self._owner.open_data_directory)
+        self.hamburger_menu.add_command(label='Open configuration directory',
+                         command=self._owner.open_config_directory)
+        self.hamburger_menu.add_separator()
         self.hamburger_menu.add_checkbutton(label='Use blitting', variable=use_blitting,
                                             command=self._owner.toggle_blitting,
                                             onvalue=True, offvalue=False)

--- a/ecris/csd/viewer/plotting/element_indicators.py
+++ b/ecris/csd/viewer/plotting/element_indicators.py
@@ -5,6 +5,7 @@ from matplotlib import transforms
 from matplotlib.figure import Figure
 from typing import List, Dict
 from itertools import compress
+from collections import deque
 
 from matplotlib.markers import MarkerStyle
 from matplotlib.text import Text
@@ -96,7 +97,7 @@ class ElementIndicator:
         return any(x_min <= x <= x_max for x in self.marker_artist.get_xdata())
 
 def add_element_indicators(elements: Dict[Element, tk.BooleanVar], figure: Figure):
-    markers = ["v", "^", "p", "d", "*", "D"]
+    markers = deque(["v", "^", "p", "d", "*", "D"])
     element_indicators = []
     ax = figure.gca()
     for element, visibility in elements.items():
@@ -107,7 +108,8 @@ def add_element_indicators(elements: Dict[Element, tk.BooleanVar], figure: Figur
         q_values = list(compress(q_values, mask))
         m_over_q = list(compress(m_over_q, mask))
         height = 0
-        marker = MarkerStyle(markers.pop(0))
+        marker = MarkerStyle(markers[0])
+        markers.rotate()
         ln, = ax.plot(m_over_q, [height]*len(m_over_q), 
                 marker=marker,
                 ms=10,


### PR DESCRIPTION
This pull request:
- Adds a persistent config.toml
- If none is present when starting, a default will be created.
- Adds an option to open the configuration directory.

The configuration file supports a default data directory, and custom elements

```toml
default_data_directory = "."

[element."Uranium"]
symbol="U"
atomic_mass=235
atomic_number=92
```